### PR TITLE
feat: https argoproj manifest with added timeout. 

### DIFF
--- a/argocd/k3d/kustomization.yaml
+++ b/argocd/k3d/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: argocd
 # To upgrade ArgoCD, increment the version here
 # https://github.com/argoproj/argo-cd/tags
 resources:
-  - github.com:argoproj/argo-cd.git/manifests/ha/cluster-install?ref=v2.6.4
+  - https://github.com/argoproj/argo-cd.git/manifests/ha/cluster-install?ref=v2.6.4&timeout=90s
   - argocd-namespace.yaml
   - argocd-ui-ingress.yaml
   - argocd-ui-ingressroute.yaml


### PR DESCRIPTION
This timeout became a blocker while working on hotspot and also guided me to a place to specify https specifically over ssh. 

resolves this error. 

```
error: accumulating resources: accumulation err='accumulating resources from 'github.com:argoproj/argo-cd.git/manifests/ha/cluster-install?ref=v2.6.4': evalsymlink failure on '/root/kubefirst/manifests/argocd/k3d/github.com:argoproj/argo-cd.git/manifests/ha/cluster-install?ref=v2.6.4' : lstat /root/kubefirst/manifests/argocd/k3d/github.com:argoproj: no such file or directory': hit 27s timeout running '/usr/bin/git fetch --depth=1 origin v2.6.4'
```

resolves https://github.com/kubefirst/kubefirst/issues/1642